### PR TITLE
Fixed a pathfinding bug when the path starts on an elevator or stair …

### DIFF
--- a/src/main/java/edu/wpi/cs3733/D21/teamB/entities/map/ETAPopup.java
+++ b/src/main/java/edu/wpi/cs3733/D21/teamB/entities/map/ETAPopup.java
@@ -40,8 +40,16 @@ public class ETAPopup extends Popup<VBox, ETAPopupData> implements Poppable {
         estimatedTimeBox.setId("estimatedTimeDialog");
         double horizPosition, vertPosition;
         Graph graph = Graph.getGraph();
-        Node secToLastNode = graph.getNodes().get(data.getPath().getPath().get(data.getPath().getPath().size() - 2));
+
         Node endNode = graph.getNodes().get(data.getPath().getPath().get(data.getPath().getPath().size() - 1));
+
+        Node secToLastNode = null;
+        try {
+            secToLastNode = graph.getNodes().get(data.getPath().getPath().get(data.getPath().getPath().size() - 2));
+        } catch (IndexOutOfBoundsException e){
+            secToLastNode = endNode;
+        }
+
         if ((secToLastNode.getXCoord() / PathfindingMenuController.COORDINATE_SCALE) < (endNode.getXCoord() / PathfindingMenuController.COORDINATE_SCALE)) {
             horizPosition = 0;
         } else {


### PR DESCRIPTION
…node and immediately goes up without placing any edges.

1. Start pathfinding on an elevator or stairway
2. Don't add any stops on the same floor as the start node
2. Set the end location to be up or down on a different floor

This should break on master but is fixed in this branch