### PR TITLE
temp user no longer appears on patient and staff database page

### DIFF
--- a/src/main/java/edu/wpi/cs3733/D21/teamB/views/menus/UserInformationDatabaseController.java
+++ b/src/main/java/edu/wpi/cs3733/D21/teamB/views/menus/UserInformationDatabaseController.java
@@ -93,7 +93,9 @@ public class UserInformationDatabaseController extends BasePageController implem
         if (users != null) {
             for (User u : users) {
                 try {
-                    tblStaff.getItems().add(new UserWrapper(u , tblStaff));
+                    if (!(u.getUsername().equals("temporary"))) {
+                        tblStaff.getItems().add(new UserWrapper(u , tblStaff));
+                    }
                 } catch (IOException err) {
                     err.printStackTrace();
                 }


### PR DESCRIPTION
prevents accidentally deleting the temp user which will break things 