### PR TITLE
hierarchical text directions

### DIFF
--- a/src/main/java/edu/wpi/cs3733/D21/teamB/entities/map/FloorSwitcher.java
+++ b/src/main/java/edu/wpi/cs3733/D21/teamB/entities/map/FloorSwitcher.java
@@ -109,7 +109,6 @@ public class FloorSwitcher {
         if (mapPathPopupManager.hasTxtDirPopup()) {
             TxtDirPopup popup = mapPathPopupManager.getTxtDirPopup();
             popup.updateEdges();
-            popup.highlight(true);
         }
     }
 

--- a/src/main/java/edu/wpi/cs3733/D21/teamB/entities/map/MapDrawer.java
+++ b/src/main/java/edu/wpi/cs3733/D21/teamB/entities/map/MapDrawer.java
@@ -221,8 +221,8 @@ public class MapDrawer implements PoppableManager {
             etaPopup = mapPathPopupManager.createETAPopup(mapCache.getFinalPath(), new Path(currentFloorPath, Graph.getGraph().calculateCost(currentFloorPath)));
 
             // Color nodes that indicate a floor swap in the path
-            colorNodesOnPathFloorSwitch(currentFloorPath);
-
+            if (!currentFloorPath.isEmpty())
+                colorNodesOnPathFloorSwitch(currentFloorPath);
         }
 
     }

--- a/src/main/java/edu/wpi/cs3733/D21/teamB/entities/map/TxtDirPopup.java
+++ b/src/main/java/edu/wpi/cs3733/D21/teamB/entities/map/TxtDirPopup.java
@@ -160,6 +160,7 @@ public class TxtDirPopup extends Popup<VBox, TxtDirPopupData> implements Poppabl
     public void close() {
         index = 0;
         highlight(true);
+        floorSwitcher.switchFloor(directions.get(1).getFloor());
         gPane.zoomTo(scaleAmount, new Point2D(gPane.getWidth() / 2, gPane.getHeight() / 2));
         gPane.centreOn(new Point2D(avgX, avgY));
         stackPane.setOnKeyPressed(null);

--- a/src/main/java/edu/wpi/cs3733/D21/teamB/entities/map/TxtDirPopup.java
+++ b/src/main/java/edu/wpi/cs3733/D21/teamB/entities/map/TxtDirPopup.java
@@ -200,6 +200,14 @@ public class TxtDirPopup extends Popup<VBox, TxtDirPopupData> implements Poppabl
      * Highlights the selected box in red, and the path in red as well
      */
     public void highlight(boolean updateScrollPane) {
+
+        // Tab in directions if on the same floor
+        for (int i = 1; i < directions.size(); i++) {
+            HBox box = (HBox) instructionBox.getChildren().get(i);
+            if (directions.get(i).getFloor().equals(mapCache.getCurrentFloor())) box.setSpacing(50);
+            else box.setSpacing(20);
+        }
+
         // Reset the previous colors to the normal color
         // Background transparentBG = new Background(new BackgroundFill(Color.TRANSPARENT, CornerRadii.EMPTY, Insets.EMPTY));
         if (previousText != null && previousLines != null) {


### PR DESCRIPTION
Increases spacing (equivalent of tab basically) for text directions on the current floor. Note that the directions are not perfectly aligned, this is due to a bug put in trello where the images are different sizes. If they were the same size, the text would be aligned