### PR TITLE
Sometimes username is still filled when face id is toggled off right …

### DIFF
--- a/src/main/java/edu/wpi/cs3733/D21/teamB/views/face/Camera.java
+++ b/src/main/java/edu/wpi/cs3733/D21/teamB/views/face/Camera.java
@@ -122,6 +122,7 @@ public class Camera {
 
             // stop the timer
             stopAcquisition();
+
         }
     }
 
@@ -245,7 +246,7 @@ public class Camera {
             e.printStackTrace();
         }
 
-        if(userName != null){
+        if(userName != null && cameraActive){
             loginPageController.setUserName(userName);
         }
     }


### PR DESCRIPTION
…when the page opens

BUG

1. open login page
2. toggle face id right when it opens
3. username is filled one time even if face id is toggled off

Fixed